### PR TITLE
Pulling latest changes into master to get ready for a release

### DIFF
--- a/config/lemur_version.php
+++ b/config/lemur_version.php
@@ -8,13 +8,13 @@ return [
     |
     */
     'portal' =>
-        ['id' => '1.3.0'],
+        ['id' => '1.4.0'],
     'bot' =>
-        ['id' => '1.3.0'],
+        ['id' => '1.4.0'],
     'release' => [
-        'name' => 'Seventeen SVT',
-        'description' => 'Bug fixes and conversation download and view plain conversation',
-        'url' => 'https://github.com/theramenrobotdiscocode/lemur-engine/releases/tag/v1.3.0',
+        'name' => 'SVT Tachycardia',
+        'description' => 'Statistics fixes - make sure we only count human turns and include processing turns',
+        'url' => 'https://github.com/theramenrobotdiscocode/lemur-engine/releases/tag/v1.4.0',
     ],
 
 ];


### PR DESCRIPTION
Statistic changes - previously stats and counts were including none-human turns from the turns table. This has been fixed now so it will only count human (actual turns)